### PR TITLE
Add nuget.config for CI fix

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Bug: https://github.com/NuGet/Home/issues/10586

Workaround: Add a `nuget.config` file to explicitly clear local package sources and add the nuget repo. I don't fully understand the ramifications of this; there might be a perf hit locally or in the CI system or both.